### PR TITLE
Fix vendor detect in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
 fn main() {
-    #[cfg(target_vendor = "apple")]
-    {
+    if let Ok("apple") = std::env::var("CARGO_CFG_TARGET_VENDOR").as_deref() {
         println!("cargo:rustc-link-lib=framework=AppKit");
     }
 }


### PR DESCRIPTION
Build script should use envirenment variable rather than `cfg()` or `env!` which is compile time things: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts

```
> cargo zigbuild --target x86_64-pc-windows-gnu -v
   Compiling dark-light v0.2.0 (/Users/han/Project/rust-dark-light)
       Fresh winapi-x86_64-pc-windows-gnu v0.4.0
       Fresh winapi v0.3.9
       Fresh winreg v0.8.0
     Running `rustc --crate-name build_script_build --edition=2018 build.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C split-debuginfo=unpacked -C debuginfo=2 -C metadata=5f6ba9f4eaf70f8d -C extra-filename=-5f6ba9f4eaf70f8d --out-dir /Users/han/.cache/rust/debug/build/dark-light-5f6ba9f4eaf70f8d -C incremental=/Users/han/.cache/rust/debug/incremental -L dependency=/Users/han/.cache/rust/debug/deps`
     Running `/Users/han/.cache/rust/debug/build/dark-light-5f6ba9f4eaf70f8d/build-script-build`
     Running `rustc --crate-name dark_light --edition=2018 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=327c3c6225612277 -C extra-filename=-327c3c6225612277 --out-dir /Users/han/.cache/rust/x86_64-pc-windows-gnu/debug/deps --target x86_64-pc-windows-gnu -C linker=/Users/han/Library/Caches/cargo-zigbuild/0.8.1/zigcc-x86_64-pc-windows-gnu.sh -C incremental=/Users/han/.cache/rust/x86_64-pc-windows-gnu/debug/incremental -L dependency=/Users/han/.cache/rust/x86_64-pc-windows-gnu/debug/deps -L dependency=/Users/han/.cache/rust/debug/deps --extern winreg=/Users/han/.cache/rust/x86_64-pc-windows-gnu/debug/deps/libwinreg-28501b6f85b0e51d.rmeta -l framework=AppKit`
warning: associated function is never used: `rgb`
  --> src/lib.rs:76:8
   |
76 |     fn rgb(r: u32, g: u32, b: u32) -> Self {
   |        ^^^
   |
   = note: `#[warn(dead_code)]` on by default

error: native frameworks are only available on macOS targets

warning: `dark-light` (lib) generated 1 warning
error: could not compile `dark-light` due to previous error; 1 warning emitted

Caused by:
  process didn't exit successfully: `rustc --crate-name dark_light --edition=2018 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=327c3c6225612277 -C extra-filename=-327c3c6225612277 --out-dir /Users/han/.cache/rust/x86_64-pc-windows-gnu/debug/deps --target x86_64-pc-windows-gnu -C linker=/Users/han/Library/Caches/cargo-zigbuild/0.8.1/zigcc-x86_64-pc-windows-gnu.sh -C incremental=/Users/han/.cache/rust/x86_64-pc-windows-gnu/debug/incremental -L dependency=/Users/han/.cache/rust/x86_64-pc-windows-gnu/debug/deps -L dependency=/Users/han/.cache/rust/debug/deps --extern winreg=/Users/han/.cache/rust/x86_64-pc-windows-gnu/debug/deps/libwinreg-28501b6f85b0e51d.rmeta -l framework=AppKit` (exit status: 1)
```