### PR TITLE
Added Default variant

### DIFF
--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -90,7 +90,7 @@ pub fn detect() -> Mode {
             DesktopEnvironment::Gnome => detect_gtk("/org/gnome/desktop/interface/gtk-theme"),
             DesktopEnvironment::Mate => detect_gtk("/org/mate/desktop/interface/gtk-theme"),
             DesktopEnvironment::Unity => detect_gtk("/org/gnome/desktop/interface/gtk-theme"),
-            _ => Mode::Light,
+            _ => Mode::Default,
         },
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! match mode {
 //!     dark_light::Mode::Dark => {},
 //!     dark_light::Mode::Light => {},
+//!     dark_light::Mode::Default => {},
 //! }
 //! ```
 
@@ -63,6 +64,7 @@ mod platform {
 pub enum Mode {
     Dark,
     Light,
+    Default,
 }
 
 impl Mode {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,17 +1,15 @@
 use crate::Mode;
 use winreg::RegKey;
 
+const SUBKEY: &str = "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+const VALUE: &str = "AppsUseLightTheme";
+
 pub fn detect() -> Mode {
     let hkcu = RegKey::predef(winreg::enums::HKEY_CURRENT_USER);
-    if let Ok(subkey) =
-        hkcu.open_subkey("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize")
-    {
-        if let Ok(dword) = subkey.get_value::<u32, _>("AppsUseLightTheme") {
+    if let Ok(subkey) = hkcu.open_subkey(SUBKEY) {
+        if let Ok(dword) = subkey.get_value::<u32, _>(VALUE) {
             Mode::from(dword == 0)
-        } else {
-            Mode::Light
         }
-    } else {
-        Mode::Light
     }
+    Mode::Light
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -8,7 +8,7 @@ pub fn detect() -> Mode {
     let hkcu = RegKey::predef(winreg::enums::HKEY_CURRENT_USER);
     if let Ok(subkey) = hkcu.open_subkey(SUBKEY) {
         if let Ok(dword) = subkey.get_value::<u32, _>(VALUE) {
-            Mode::from(dword == 0)
+            return Mode::from(dword == 0);
         }
     }
     Mode::Light


### PR DESCRIPTION
- Added `Default` variant to comply with the FreeDesktop [specification](https://flatpak.github.io/xdg-desktop-portal/#gdbus-org.freedesktop.impl.portal.Settings).
- macOS and Windows remain using only `Light` and `Dark` variants.

Closes #23 