### PR TITLE
Remove `eprintln!()` from KDE configuration read error

### DIFF
--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -66,10 +66,7 @@ fn detect_kde(path: &str) -> Mode {
             let (r, g, b) = (rgb[0], rgb[1], rgb[2]);
             Mode::rgb(r, g, b)
         }
-        Err(e) => {
-            eprintln!("{:?}", e);
-            Mode::Light
-        }
+        Err(_) => Mode::Light,
     }
 }
 


### PR DESCRIPTION
It's bad practice to print out things like this from a library. It could make sense to add in some logging to give more insight into what methods work or fail considering the amount of different detection methods and fallbacks used for freedesktop though