### PR TITLE
Fix CI branch trigger

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
It looks like the main branch was probably renamed a few months ago, so this should cause CI to start getting triggered again