### PR TITLE
Update to detect-desktop-environment 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.79"
 tokio = { version = "1.23.0", features = ["full"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-detect-desktop-environment = "1.0.0"
+detect-desktop-environment = "1.1.0"
 dconf_rs = "0.3"
 zbus = "3.0"
 rust-ini = "0.20"


### PR DESCRIPTION
This commit updates the dependency `detect-desktop-environment` to its latest version. The highlights of this version are fixed parsing of composite desktop descriptions (such as `ubuntu:GNOME`) and the addition of 10 more DEs. See [CHANGELOG](https://github.com/demurgos/detect-desktop-environment/blob/main/CHANGELOG.md#110-2024-04-16).