### PR TITLE
Use `objc2-foundation` and `objc2-app-kit`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,17 @@ xdg = "2.4.1"
 winreg = "0.52.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc = "0.2"
+objc2 = "0.5.1"
+objc2-foundation = { version = "0.2.0", features = [
+    "NSArray",
+    "NSObject",
+    "NSString",
+] }
+objc2-app-kit = { version = "0.2.0", features = [
+    "NSAppearance",
+    "NSApplication",
+    "NSResponder",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["MediaQueryList", "Window"] }


### PR DESCRIPTION
The [`objc2`](https://github.com/madsmtm/objc2) project is the successor to `objc`, and contains automatically generated bindings to the Foundation and AppKit frameworks (and many other frameworks), while ensuring that memory management rules are upheld.

This allows `dark-light` to reduce the amount of complex `unsafe` code, as well as making it easier for you to in the future change `subscribe` to listen for theme change notifications instead of the busy loop.