### PR TITLE
Make `zbus` Optional,  Remove `anyhow`, Fix `notify` Example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-futures = "0.3.30"
+futures = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1.40.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ tokio = { version = "1.40.0", features = ["full"] }
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 detect-desktop-environment = "1.1.0"
 dconf_rs = "0.3"
-zbus = "4.4"
+zbus = { version = "4.4", optional = true }
+ashpd = { version = "0.9", optional = true }
 rust-ini = "0.21"
-ashpd = "0.9"
 xdg = "2.5"
 
 [target.'cfg(windows)'.dependencies]
@@ -32,3 +32,6 @@ objc = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["MediaQueryList", "Window"] }
+
+[features]
+zbus = ["dep:zbus", "dep:ashpd"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,18 +11,18 @@ build = "build.rs"
 
 [dependencies]
 futures = "0.3.30"
-anyhow = "1.0.79"
+anyhow = "1.0.89"
 
 [dev-dependencies]
-tokio = { version = "1.23.0", features = ["full"] }
+tokio = { version = "1.40.0", features = ["full"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-detect-desktop-environment = "1.0.0"
+detect-desktop-environment = "1.1.0"
 dconf_rs = "0.3"
-zbus = "3.0"
-rust-ini = "0.20"
-ashpd = "0.7.0"
-xdg = "2.4.1"
+zbus = "4.4"
+rust-ini = "0.21"
+ashpd = "0.9"
+xdg = "2.5"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ build = "build.rs"
 
 [dependencies]
 futures = "0.3.30"
-anyhow = "1.0.89"
 
 [dev-dependencies]
 tokio = { version = "1.40.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ fn main() {
 }
 ```
 
+On platforms which make use of xdg-desktop-portals, by default this crate uses the `dbus-send` and `dbus-monitor` commands to avoid heavy dependencies.
+If you already depend on `zbus` or `ashpd`, you should enable the `zbus` feature.
+
 ## Example
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ fn main() {
         // Light mode
         dark_light::Mode::Light => {},
         // Unspecified
-        dark_light::Mode::Default => {},
+        dark_light::Mode::NoPreference => {},
     }
 }
 ```
@@ -35,5 +35,3 @@ Licensed under either of
  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
-
-

--- a/examples/notify.rs
+++ b/examples/notify.rs
@@ -1,7 +1,9 @@
+use std::error::Error;
+
 use futures::StreamExt;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     let mut stream = dark_light::subscribe().await?;
     while let Some(mode) = stream.next().await {
         println!("System theme changed: {:?}", mode);

--- a/examples/notify.rs
+++ b/examples/notify.rs
@@ -2,7 +2,8 @@ use futures::StreamExt;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    while let Some(mode) = dark_light::subscribe().await?.next().await {
+    let mut stream = dark_light::subscribe().await?;
+    while let Some(mode) = stream.next().await {
         println!("System theme changed: {:?}", mode);
     }
 

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -24,7 +24,7 @@ fn get_freedesktop_color_scheme() -> Option<Mode> {
         if theme.is_err() {
             return None;
         }
-    
+
         match theme.unwrap() {
             1 => Some(Mode::Dark),
             2 => Some(Mode::Light),
@@ -86,7 +86,7 @@ pub fn detect() -> Mode {
             DesktopEnvironment::Gnome => detect_gtk("/org/gnome/desktop/interface/gtk-theme"),
             DesktopEnvironment::Mate => detect_gtk("/org/mate/desktop/interface/gtk-theme"),
             DesktopEnvironment::Unity => detect_gtk("/org/gnome/desktop/interface/gtk-theme"),
-            _ => Mode::Default,
+            _ => Mode::NoPreference,
         },
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 //! ```
 
 mod platforms;
+
 use platforms::platform;
 
 mod utils;
@@ -29,13 +30,14 @@ mod utils;
 use utils::rgb::Rgb;
 
 /// Enum representing dark mode, light mode, or unspecified.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub enum Mode {
     /// Dark mode
     Dark,
     /// Light mode
     Light,
     /// Unspecified
+    #[default]
     NoPreference,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!     // Light mode
 //!     dark_light::Mode::Light => {},
 //!     // Unspecified
-//!     dark_light::Mode::Default => {},
+//!     dark_light::Mode::NoPreference => {},
 //! }
 //! ```
 
@@ -36,7 +36,7 @@ pub enum Mode {
     /// Light mode
     Light,
     /// Unspecified
-    Default,
+    NoPreference,
 }
 
 impl Mode {
@@ -67,7 +67,7 @@ impl Mode {
     }
 }
 
-/// Detect if light mode or dark mode is enabled. If the mode can’t be detected, fall back to [`Mode::Default`].
+/// Detect if light mode or dark mode is enabled. If the mode can’t be detected, fall back to [`Mode::NoPreference`].
 pub use platform::detect::detect;
 /// Notifies the user if the system theme has been changed.
 pub use platform::notify::subscribe;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,14 @@ impl Mode {
             Self::Light
         }
     }
+
+    fn concrete(self) -> Option<Self> {
+        match self {
+            Mode::Dark => Some(Mode::Dark),
+            Mode::Light => Some(Mode::Light),
+            Mode::NoPreference => None,
+        }
+    }
 }
 
 /// Detect if light mode or dark mode is enabled. If the mode can’t be detected, fall back to [`Mode::NoPreference`].

--- a/src/platforms/freedesktop/detect.rs
+++ b/src/platforms/freedesktop/detect.rs
@@ -33,15 +33,15 @@ impl ColorScheme for NonFreeDesktop {
             Some(mode) => match mode {
                 DesktopEnvironment::Kde => match kde_detect() {
                     Ok(mode) => mode,
-                    Err(_) => Mode::Default,
+                    Err(_) => Mode::NoPreference,
                 },
                 DesktopEnvironment::Cinnamon => dconf_detect(CINNAMON),
                 DesktopEnvironment::Gnome => dconf_detect(GNOME),
                 DesktopEnvironment::Mate => dconf_detect(MATE),
                 DesktopEnvironment::Unity => dconf_detect(GNOME),
-                _ => Mode::Default,
+                _ => Mode::NoPreference,
             },
-            None => Mode::Default,
+            None => Mode::NoPreference,
         }
     }
 }

--- a/src/platforms/freedesktop/detect.rs
+++ b/src/platforms/freedesktop/detect.rs
@@ -62,10 +62,7 @@ impl ColorScheme for NonFreeDesktop {
     fn detect() -> Mode {
         match DesktopEnvironment::detect() {
             Some(mode) => match mode {
-                DesktopEnvironment::Kde => match kde_detect() {
-                    Ok(mode) => mode,
-                    Err(_) => Mode::NoPreference,
-                },
+                DesktopEnvironment::Kde => kde_detect(),
                 DesktopEnvironment::Cinnamon => dconf_detect(CINNAMON),
                 DesktopEnvironment::Gnome => dconf_detect(GNOME),
                 DesktopEnvironment::Mate => dconf_detect(MATE),

--- a/src/platforms/freedesktop/mod.rs
+++ b/src/platforms/freedesktop/mod.rs
@@ -21,7 +21,7 @@ fn dconf_detect(path: &str) -> Mode {
                 Mode::Light
             }
         }
-        Err(_) => Mode::Default,
+        Err(_) => Mode::NoPreference,
     }
 }
 
@@ -41,10 +41,11 @@ fn kde_detect() -> anyhow::Result<Mode> {
     Ok(Mode::from_rgb(rgb))
 }
 
+#[cfg(feature = "zbus")]
 impl From<ashpd::desktop::settings::ColorScheme> for Mode {
     fn from(value: ashpd::desktop::settings::ColorScheme) -> Self {
         match value {
-            ashpd::desktop::settings::ColorScheme::NoPreference => Mode::Default,
+            ashpd::desktop::settings::ColorScheme::NoPreference => Mode::NoPreference,
             ashpd::desktop::settings::ColorScheme::PreferDark => Mode::Dark,
             ashpd::desktop::settings::ColorScheme::PreferLight => Mode::Light,
         }

--- a/src/platforms/freedesktop/notify.rs
+++ b/src/platforms/freedesktop/notify.rs
@@ -1,11 +1,46 @@
-use futures::{stream, Stream, StreamExt};
-use std::task::Poll;
+use crate::Mode;
+use futures::Stream;
 
-use crate::{detect, Mode};
-
+#[cfg(not(feature = "zbus"))]
 pub async fn subscribe() -> anyhow::Result<impl Stream<Item = Mode> + Send> {
+    use futures::stream;
+    use std::{
+        io::{BufRead, BufReader},
+        process::{Command, Stdio},
+    };
+    let mut process = Command::new("dbus-monitor")
+        .arg(
+            "type='signal',\
+            sender='org.freedesktop.portal.Desktop',\
+            path='/org/freedesktop/portal/desktop',\
+            interface='org.freedesktop.portal.Settings',\
+            member='SettingChanged',\
+            arg0='org.freedesktop.appearance',\
+            arg1='color-scheme'",
+        )
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let stdout = process.stdout.take().unwrap();
+    let lines = BufReader::new(stdout).lines();
+    Ok(stream::iter(lines.filter_map(
+        |line| match line.ok()?.chars().last()? {
+            '0' => Some(Mode::NoPreference),
+            '1' => Some(Mode::Dark),
+            '2' => Some(Mode::Light),
+            _ => None,
+        },
+    )))
+}
+
+#[cfg(feature = "zbus")]
+pub async fn subscribe() -> anyhow::Result<impl Stream<Item = Mode> + Send> {
+    use crate::detect;
+    use futures::{stream, StreamExt};
+    use std::task::Poll;
     let stream = if get_freedesktop_color_scheme().await.is_ok() {
-        let proxy = ashpd::desktop::Settings::new().await?;
+        let proxy = ashpd::desktop::settings::Settings::new().await?;
         proxy
             .receive_color_scheme_changed()
             .await?
@@ -29,8 +64,9 @@ pub async fn subscribe() -> anyhow::Result<impl Stream<Item = Mode> + Send> {
     Ok(stream)
 }
 
+#[cfg(feature = "zbus")]
 async fn get_freedesktop_color_scheme() -> anyhow::Result<Mode> {
-    let proxy = ashpd::desktop::Settings::new().await?;
+    let proxy = ashpd::desktop::settings::Settings::new().await?;
     let color_scheme = proxy.color_scheme().await?;
     let mode = color_scheme.into();
     Ok(mode)

--- a/src/platforms/freedesktop/notify.rs
+++ b/src/platforms/freedesktop/notify.rs
@@ -1,4 +1,3 @@
-use ashpd::desktop::settings::{ColorScheme, Settings};
 use futures::{stream, Stream, StreamExt};
 use std::task::Poll;
 
@@ -6,7 +5,7 @@ use crate::{detect, Mode};
 
 pub async fn subscribe() -> anyhow::Result<impl Stream<Item = Mode> + Send> {
     let stream = if get_freedesktop_color_scheme().await.is_ok() {
-        let proxy = Settings::new().await?;
+        let proxy = ashpd::desktop::Settings::new().await?;
         proxy
             .receive_color_scheme_changed()
             .await?
@@ -31,12 +30,8 @@ pub async fn subscribe() -> anyhow::Result<impl Stream<Item = Mode> + Send> {
 }
 
 async fn get_freedesktop_color_scheme() -> anyhow::Result<Mode> {
-    let proxy = Settings::new().await?;
+    let proxy = ashpd::desktop::Settings::new().await?;
     let color_scheme = proxy.color_scheme().await?;
-    let mode = match color_scheme {
-        ColorScheme::PreferDark => Mode::Dark,
-        ColorScheme::PreferLight => Mode::Light,
-        ColorScheme::NoPreference => Mode::Default,
-    };
+    let mode = color_scheme.into();
     Ok(mode)
 }

--- a/src/platforms/macos/notify.rs
+++ b/src/platforms/macos/notify.rs
@@ -1,10 +1,11 @@
+use std::error::Error;
 use std::task::Poll;
 
 use futures::{stream, Stream};
 
 use crate::{detect, Mode};
 
-pub async fn subscribe() -> anyhow::Result<impl Stream<Item = Mode> + Send> {
+pub async fn subscribe() -> Result<impl Stream<Item = Mode> + Send, Box<dyn Error>> {
     let mut last_mode = detect();
 
     let stream = stream::poll_fn(move |ctx| -> Poll<Option<Mode>> {

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -43,6 +43,6 @@ pub use websys as platform;
 )))]
 pub mod platform {
     pub fn detect() -> crate::Mode {
-        super::Mode::Light
+        super::Mode::NoPreference
     }
 }

--- a/src/platforms/websys/notify.rs
+++ b/src/platforms/websys/notify.rs
@@ -1,10 +1,11 @@
+use std::error::Error;
 use std::task::Poll;
 
 use futures::{stream, Stream};
 
 use crate::{detect, Mode};
 
-pub async fn subscribe() -> anyhow::Result<impl Stream<Item = Mode> + Send> {
+pub async fn subscribe() -> Result<impl Stream<Item = Mode> + Send, Box<dyn Error>> {
     let mut last_mode = detect();
 
     let stream = stream::poll_fn(move |ctx| -> Poll<Option<Mode>> {

--- a/src/platforms/windows/notify.rs
+++ b/src/platforms/windows/notify.rs
@@ -1,10 +1,11 @@
+use std::error::Error;
 use std::task::Poll;
 
 use futures::{stream, Stream};
 
 use crate::{detect, Mode};
 
-pub async fn subscribe() -> anyhow::Result<impl Stream<Item = Mode> + Send> {
+pub async fn subscribe() -> Result<impl Stream<Item = Mode> + Send, Box<dyn Error>> {
     let mut last_mode = detect();
 
     let stream = stream::poll_fn(move |ctx| -> Poll<Option<Mode>> {

--- a/src/utils/rgb.rs
+++ b/src/utils/rgb.rs
@@ -3,8 +3,10 @@ use std::str::FromStr;
 /// Struct representing an RGB color
 pub(crate) struct Rgb(pub(crate) u32, pub(crate) u32, pub(crate) u32);
 
+pub struct ParseError;
+
 impl FromStr for Rgb {
-    type Err = anyhow::Error;
+    type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let rgb = s
@@ -15,7 +17,7 @@ impl FromStr for Rgb {
                     acc.push(x);
                     Ok(acc)
                 } else {
-                    Err(anyhow::anyhow!("RGB format is invalid"))
+                    Err(ParseError)
                 }
             })?;
         Ok(Rgb(rgb[0], rgb[1], rgb[2]))


### PR DESCRIPTION
I discovered `--print-reply=literal` for `dbus-send` and `argN=` for `dbus-monitor` which make the logic nicer, `detect` is in a very good state, `subscribe` is a bit more fragile in terms of forward compatibility, but I think it's good enough to merge it.

On my system `notify` sends each notification twice, I originally had some logic to deduplicate it, but it also happens with `zbus` so it's probably a Gnome bug. (It might still be useful to have it regardless?)

Fixes #34, #15 (FWIW, I agree with @parasyte, being pure-rust isn't a very compelling argument for a abstraction crate such as this, and this crate being important for accessibility and `zbus` being used in `accesskit` has almost nothing to do with how this crate is implemented. This crate *feels* like it should be light, so it should be light - depending on an heavy crate breaks user expectation and leads to frustration.)

Edit: I'm not sure if `Mode::Preference` implementing `Default` is a good idea, people might think it detects the theme, and I can't think of a reason to use it outside the implementation, as users will most likely convert it to their own type. I'm not sure it even `Mode::Preference` needs to exist, as `Option<Mode>` can express the same thing.