### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1.40.0", features = ["full"] }
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 detect-desktop-environment = "1.1.0"
 dconf_rs = "0.3"
-zbus = "4.4"
+zbus = "4"
 rust-ini = "0.21"
 ashpd = "0.9"
 xdg = "2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,18 +11,18 @@ build = "build.rs"
 
 [dependencies]
 futures = "0.3.30"
-anyhow = "1.0.79"
+anyhow = "1.0.89"
 
 [dev-dependencies]
-tokio = { version = "1.23.0", features = ["full"] }
+tokio = { version = "1.40.0", features = ["full"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 detect-desktop-environment = "1.1.0"
 dconf_rs = "0.3"
-zbus = "3.0"
-rust-ini = "0.20"
-ashpd = "0.7.0"
-xdg = "2.4.1"
+zbus = "4.4"
+rust-ini = "0.21"
+ashpd = "0.9"
+xdg = "2.5"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-futures = "0.3.30"
+futures = "0.3"
 anyhow = "1.0.89"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dark-light"
 version = "1.1.1"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
-edition = "2018"
+edition = "2021"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/frewsxcv/rust-dark-light"
 description = "Detect if dark mode or light mode is enabled"


### PR DESCRIPTION
Among other things this helps with reducing duplicated `zbus` dependencies, e.g. with `rust-notify` and recent `ashpd` versions.