### PR TITLE
remove anyhow dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ build = "build.rs"
 
 [dependencies]
 futures = "0.3.30"
-anyhow = "1.0.79"
 
 [dev-dependencies]
 tokio = { version = "1.23.0", features = ["full"] }

--- a/examples/notify.rs
+++ b/examples/notify.rs
@@ -1,11 +1,9 @@
 use futures::StreamExt;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let mut stream = dark_light::subscribe().await?;
+async fn main() {
+    let mut stream = dark_light::subscribe().await.unwrap();
     while let Some(mode) = stream.next().await {
         println!("System theme changed: {:?}", mode);
     }
-
-    Ok(())
 }

--- a/src/platforms/freedesktop/notify.rs
+++ b/src/platforms/freedesktop/notify.rs
@@ -1,9 +1,10 @@
+use std::error::Error;
 use ashpd::desktop::settings::Settings;
 use futures::{stream, Stream, StreamExt};
 
 use crate::Mode;
 
-pub async fn subscribe() -> anyhow::Result<impl Stream<Item = Mode> + Send> {
+pub async fn subscribe() -> Result<impl Stream<Item = Mode> + Send, Box<dyn Error>> {
     let initial = stream::once(super::initial_value()).boxed();
     let later_updates = Settings::new()
         .await?

--- a/src/platforms/macos/notify.rs
+++ b/src/platforms/macos/notify.rs
@@ -1,10 +1,11 @@
 use std::task::Poll;
+use std::error::Error;
 
 use futures::{stream, Stream};
 
 use crate::{detect, Mode};
 
-pub async fn subscribe() -> anyhow::Result<impl Stream<Item = Mode> + Send> {
+pub async fn subscribe() -> Result<impl Stream<Item = Mode> + Send, Box<dyn Error>> {
     let mut last_mode = detect();
 
     let stream = stream::poll_fn(move |ctx| -> Poll<Option<Mode>> {

--- a/src/platforms/websys/notify.rs
+++ b/src/platforms/websys/notify.rs
@@ -1,10 +1,11 @@
 use std::task::Poll;
+use std::error::Error;
 
 use futures::{stream, Stream};
 
 use crate::{detect, Mode};
 
-pub async fn subscribe() -> anyhow::Result<impl Stream<Item = Mode> + Send> {
+pub async fn subscribe() -> Result<impl Stream<Item = Mode> + Send, Box<dyn Error>> {
     let mut last_mode = detect();
 
     let stream = stream::poll_fn(move |ctx| -> Poll<Option<Mode>> {

--- a/src/platforms/windows/notify.rs
+++ b/src/platforms/windows/notify.rs
@@ -1,10 +1,11 @@
 use std::task::Poll;
+use std::error::Error;
 
 use futures::{stream, Stream};
 
 use crate::{detect, Mode};
 
-pub async fn subscribe() -> anyhow::Result<impl Stream<Item = Mode> + Send> {
+pub async fn subscribe() -> Result<impl Stream<Item = Mode> + Send, Box<dyn Error>> {
     let mut last_mode = detect();
 
     let stream = stream::poll_fn(move |ctx| -> Poll<Option<Mode>> {


### PR DESCRIPTION
Nothing from anyhow was being used, anyhow. std::error::Error is fine.