### PR TITLE
Use `futures-lite` instead of `futures` and `pollster`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ path = "examples/sync.rs"
 required-features = ["sync"]
 
 [features]
-sync = ["pollster"]
+sync = []
 
 [dependencies]
-futures = "0.3.30"
+futures-lite = "2.3.0"
 log = "0.4.22"
 
 [dev-dependencies]
@@ -26,7 +26,6 @@ tokio = { version = "1.23.0", features = ["full"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 ashpd = "0.9.1"
-pollster = { version = "0.3.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,4 +1,4 @@
-use futures::StreamExt;
+use futures_lite::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/notify.rs
+++ b/examples/notify.rs
@@ -1,0 +1,13 @@
+use std::error::Error;
+
+use futures_lite::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let mut stream = dark_light::subscribe().await;
+    while let Some(mode) = stream.next().await {
+        println!("System theme changed: {:?}", mode);
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub use platforms::platform::detect::detect;
 ///
 /// ``` no_run
 /// use dark_light::Mode;
-/// use futures::stream::StreamExt;
+/// use futures_lite::stream::StreamExt;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -66,7 +66,7 @@ pub mod sync {
     ///
     /// ``` no_run
     /// use dark_light::Mode;
-    ///     
+    ///
     /// let mode = dark_light::sync::detect();
     ///
     /// match mode {

--- a/src/platforms/freedesktop/detect.rs
+++ b/src/platforms/freedesktop/detect.rs
@@ -3,7 +3,7 @@ pub mod sync {
     use crate::Mode;
 
     pub fn detect() -> Mode {
-        pollster::block_on(super::super::get_color_scheme())
+        futures_lite::future::block_on(super::super::get_color_scheme())
     }
 }
 

--- a/src/platforms/freedesktop/notify.rs
+++ b/src/platforms/freedesktop/notify.rs
@@ -1,0 +1,17 @@
+use std::error::Error;
+
+use ashpd::desktop::settings::Settings;
+use futures_lite::{stream, Stream, StreamExt};
+
+use crate::Mode;
+
+pub async fn subscribe() -> Result<impl Stream<Item = Mode> + Send, Box<dyn Error>> {
+    let initial = stream::once(super::get_color_scheme().await).boxed();
+    let later_updates = Settings::new()
+        .await?
+        .receive_color_scheme_changed()
+        .await?
+        .map(Mode::from)
+        .boxed();
+    Ok(initial.chain(later_updates))
+}

--- a/src/platforms/freedesktop/subscribe.rs
+++ b/src/platforms/freedesktop/subscribe.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use ashpd::desktop::settings::Settings;
-use futures::{stream, Stream, StreamExt};
+use futures_lite::{stream, Stream, StreamExt};
 
 use crate::Mode;
 
@@ -9,13 +9,13 @@ use crate::Mode;
 pub(crate) mod sync {
     use super::super::Mode;
     use super::color_scheme_stream;
-    use futures::StreamExt;
+    use futures_lite::StreamExt;
 
     pub fn subscribe() -> std::sync::mpsc::Receiver<Mode> {
         let (tx, rx) = std::sync::mpsc::channel();
 
         std::thread::spawn(move || {
-            pollster::block_on(async {
+            futures_lite::future::block_on(async {
                 let stream = match color_scheme_stream().await {
                     Ok(stream) => stream,
                     Err(err) => {
@@ -27,7 +27,6 @@ pub(crate) mod sync {
                 stream
                     .for_each(|mode| {
                         let _ = tx.send(mode);
-                        async {}
                     })
                     .await;
             });
@@ -48,12 +47,11 @@ pub async fn subscribe() -> impl Stream<Item = Mode> + Send {
 }
 
 pub async fn color_scheme_stream() -> Result<impl Stream<Item = Mode> + Send, Box<dyn Error>> {
-    let initial = stream::once(super::get_color_scheme()).boxed();
+    let initial = stream::once_future(super::get_color_scheme());
     let later_updates = Settings::new()
         .await?
         .receive_color_scheme_changed()
         .await?
-        .map(Mode::from)
-        .boxed();
+        .map(Mode::from);
     Ok(Box::pin(initial.chain(later_updates)))
 }

--- a/src/platforms/macos/notify.rs
+++ b/src/platforms/macos/notify.rs
@@ -1,0 +1,24 @@
+use std::error::Error;
+use std::task::Poll;
+
+use futures_lite::{stream, Stream};
+
+use crate::{detect, Mode};
+
+pub async fn subscribe() -> Result<impl Stream<Item = Mode> + Send, Box<dyn Error>> {
+    let mut last_mode = detect();
+
+    let stream = stream::poll_fn(move |ctx| -> Poll<Option<Mode>> {
+        let current_mode = detect();
+
+        if current_mode != last_mode {
+            last_mode = current_mode;
+            Poll::Ready(Some(current_mode))
+        } else {
+            ctx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    });
+
+    Ok(stream)
+}

--- a/src/platforms/macos/subscribe.rs
+++ b/src/platforms/macos/subscribe.rs
@@ -23,8 +23,8 @@ pub(crate) mod sync {
     }
 }
 
-pub async fn subscribe() -> impl futures::Stream<Item = Mode> {
-    Box::pin(futures::stream::unfold(
+pub async fn subscribe() -> impl futures_lite::Stream<Item = Mode> {
+    Box::pin(futures_lite::stream::unfold(
         crate::detect().await,
         |last_mode| async move {
             loop {

--- a/src/platforms/websys/notify.rs
+++ b/src/platforms/websys/notify.rs
@@ -1,0 +1,24 @@
+use std::error::Error;
+use std::task::Poll;
+
+use futures_lite::{stream, Stream};
+
+use crate::{detect, Mode};
+
+pub async fn subscribe() -> Result<impl Stream<Item = Mode> + Send, Box<dyn Error>> {
+    let mut last_mode = detect();
+
+    let stream = stream::poll_fn(move |ctx| -> Poll<Option<Mode>> {
+        let current_mode = detect();
+
+        if current_mode != last_mode {
+            last_mode = current_mode;
+            Poll::Ready(Some(current_mode))
+        } else {
+            ctx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    });
+
+    Ok(stream)
+}

--- a/src/platforms/websys/subscribe.rs
+++ b/src/platforms/websys/subscribe.rs
@@ -21,8 +21,8 @@ pub(crate) mod sync {
     }
 }
 
-pub async fn subscribe() -> impl futures::Stream<Item = crate::Mode> {
-    Box::pin(futures::stream::unfold(
+pub async fn subscribe() -> impl futures_lite::Stream<Item = crate::Mode> {
+    Box::pin(futures_lite::stream::unfold(
         crate::detect().await,
         |last_mode| async move {
             loop {

--- a/src/platforms/windows/notify.rs
+++ b/src/platforms/windows/notify.rs
@@ -1,0 +1,24 @@
+use std::error::Error;
+use std::task::Poll;
+
+use futures_lite::{stream, Stream};
+
+use crate::{detect, Mode};
+
+pub async fn subscribe() -> Result<impl Stream<Item = Mode> + Send, Box<dyn Error>> {
+    let mut last_mode = detect();
+
+    let stream = stream::poll_fn(move |ctx| -> Poll<Option<Mode>> {
+        let current_mode = detect();
+
+        if current_mode != last_mode {
+            last_mode = current_mode;
+            Poll::Ready(Some(current_mode))
+        } else {
+            ctx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    });
+
+    Ok(stream)
+}

--- a/src/platforms/windows/subscribe.rs
+++ b/src/platforms/windows/subscribe.rs
@@ -25,8 +25,8 @@ pub(crate) mod sync {
     }
 }
 
-pub async fn subscribe() -> impl futures::Stream<Item = Mode> {
-    Box::pin(futures::stream::unfold(
+pub async fn subscribe() -> impl futures_lite::Stream<Item = Mode> {
+    Box::pin(futures_lite::stream::unfold(
         crate::detect().await,
         |last_mode| async move {
             loop {


### PR DESCRIPTION
We only use `Stream`, `StreamExt`, `steam::once` and `block_on`, `futures` is overkill (and already depended on with `ashpd`) and afaict there's no reason to use `pollster` when we depend on either of those.

I don't really know how to compare it, FWIW the lock file is a bit smaller now, you can't see `futures-lite` in the diff because it was already there (P.S. not sure it should be ignored, [rust switched to being natural about this](https://blog.rust-lang.org/2023/08/29/committing-lockfiles.html) and does not ignore it by default anymore)
```diff
diff --git a/home/bbb651/Cargo.lock.old b/home/bbb651/Cargo.lock.new
index 3da747d..a86bbb1 100644
--- a/home/bbb651/Cargo.lock.old
+++ b/home/bbb651/Cargo.lock.new
@@ -322,12 +322,11 @@ name = "dark-light"
 version = "1.1.1"
 dependencies = [
  "ashpd",
- "futures",
+ "futures-lite",
  "log",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
- "pollster",
  "tokio",
  "web-sys",
  "winreg",
@@ -422,53 +421,26 @@ dependencies = [
  "percent-encoding",
 ]
 
-[[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
@@ -485,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -496,23 +468,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -881,12 +852,6 @@ dependencies = [
  "windows-sys 0.59.0",
 ]
 
-[[package]]
-name = "pollster"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
-
 [[package]]
 name = "portable-atomic"
 version = "1.9.0"
```