### PR TITLE
update ashpd to v0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4.22"
 tokio = { version = "1.23.0", features = ["full"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-ashpd = "0.9.1"
+ashpd = "0.10.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"


### PR DESCRIPTION
This transitively updates zbus to v5, which would help in avoiding duplicate dependencies in projects using dark-light.