### PR TITLE
Bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-light"
-version = "2.0.0"
+version = "2.0.1"
 authors = [
     "Corey Farwell <coreyf@rwell.org>",
     "Eduardo Flores <edflores@proton.me>",
@@ -11,7 +11,6 @@ repository = "https://github.com/rust-dark-light/rust-dark-light"
 description = "Detect if dark mode or light mode is enabled"
 readme = "README.md"
 build = "build.rs"
-rust-version = "1.78.0"
 
 [features]
 default = ["async-io"]
@@ -21,13 +20,13 @@ async-io = ["zbus/async-io"]
 [dependencies]
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-zbus = "5.5.0"
+zbus = "5.19.0"
 
 [target.'cfg(windows)'.dependencies]
-winreg = "0.55.0"
+winreg = "0.56.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.6.3"
+objc2 = "0.6.4"
 objc2-foundation = { version = "0.3.2", default-features = false, features = [
     "std",
     "NSObject",


### PR DESCRIPTION
Bump version and update deps.
Fixed this issue for me:
```
Crate:     async-std
Version:   1.13.2
Warning:   unmaintained
Title:     async-std has been discontinued
Date:      2025-08-24
ID:        RUSTSEC-2025-0052
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0052
Dependency tree:
async-std 1.13.2
└── dark-light 2.0.0
    └── my_package 0.1.0
```