### PR TITLE
feat: support reacting to theme changes via subscribe() and stream()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,16 @@ rust-version = "1.78.0"
 
 [features]
 default = ["async-io"]
-tokio = ["zbus/tokio"]
-async-io = ["zbus/async-io"]
+tokio = ["zbus/tokio", "dep:futures-core", "dep:futures-channel"]
+async-io = ["zbus/async-io", "dep:futures-core", "dep:futures-channel"]
 
 [dependencies]
+futures-core = { version = "0.3", optional = true }
+futures-channel = { version = "0.3", optional = true }
+
+[dev-dependencies]
+futures-util = "0.3"
+futures-executor = "0.3"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 zbus = "5.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ zbus = "5.5.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55.0"
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_System_Registry",
+] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.3"
@@ -37,4 +41,5 @@ objc2-foundation = { version = "0.3.2", default-features = false, features = [
 ] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { version = "0.3", features = ["MediaQueryList", "Window"] }
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = ["MediaQueryList", "Window", "EventTarget", "Event"] }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ fn main() -> Result<(), dark_light::Error> {
 }
 ```
 
+### React to theme changes
+You can subscribe to theme changes by using the `subscribe` function. It returns a `Watcher` that yields a new `Mode` each time the OS theme changes.
+```rust
+fn main() -> Result<(), dark_light::Error> {
+    let watcher = dark_light::subscribe()?;
+    for mode in watcher.iter() {
+        match mode {
+            dark_light::Mode::Dark => println!("Dark mode"),
+            dark_light::Mode::Light => println!("Light mode"),
+            dark_light::Mode::Unspecified => println!("Unspecified"),
+        }
+    }
+    Ok(())
+}
+```
+On macOS, theme changes are currently detected by polling once per second rather than through a native notification, since the objc2 bindings this crate uses don't yet expose a safe way to observe `NSDistributedNotificationCenter`.
+
 ## License
 
 Licensed under either of the following licenses:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ fn main() -> Result<(), dark_light::Error> {
 ```
 On macOS, theme changes are currently detected by polling once per second rather than through a native notification, since the objc2 bindings this crate uses don't yet expose a safe way to observe `NSDistributedNotificationCenter`.
 
+### Async theme changes
+With the default `async-io` feature (or `tokio`) enabled, `stream` returns a [`futures_core::Stream`](https://docs.rs/futures-core) of `Mode`.
+```rust
+use futures_util::StreamExt;
+
+async fn watch_theme() -> Result<(), dark_light::Error> {
+    let mut stream = dark_light::stream()?;
+    while let Some(mode) = stream.next().await {
+        println!("{mode:?}");
+    }
+    Ok(())
+}
+```
+
 ## License
 
 Licensed under either of the following licenses:

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -1,0 +1,22 @@
+#[cfg(any(feature = "tokio", feature = "async-io"))]
+fn main() -> Result<(), dark_light::Error> {
+    use futures_util::StreamExt;
+
+    futures_executor::block_on(async {
+        let mut stream = dark_light::stream()?;
+        println!("Watching for theme changes, toggle your system theme to see updates...");
+        while let Some(mode) = stream.next().await {
+            match mode {
+                dark_light::Mode::Dark => println!("Dark mode"),
+                dark_light::Mode::Light => println!("Light mode"),
+                dark_light::Mode::Unspecified => println!("Unspecified"),
+            }
+        }
+        Ok(())
+    })
+}
+
+#[cfg(not(any(feature = "tokio", feature = "async-io")))]
+fn main() {
+    eprintln!("This example requires the `tokio` or `async-io` feature.");
+}

--- a/examples/watch.rs
+++ b/examples/watch.rs
@@ -1,0 +1,12 @@
+fn main() -> Result<(), dark_light::Error> {
+    let watcher = dark_light::subscribe()?;
+    println!("Watching for theme changes, toggle your system theme to see updates...");
+    for mode in watcher.iter() {
+        match mode {
+            dark_light::Mode::Dark => println!("Dark mode"),
+            dark_light::Mode::Light => println!("Light mode"),
+            dark_light::Mode::Unspecified => println!("Unspecified"),
+        }
+    }
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,8 @@ pub enum Error {
     MediaQueryFailed,
     /// If the media query is not supported.
     MediaQueryNotSupported,
+    /// If watching for theme changes is not supported on this platform.
+    Unsupported,
 }
 
 impl Display for Error {
@@ -31,6 +33,10 @@ impl Display for Error {
             Error::WindowNotFound => write!(f, "Window not found"),
             Error::MediaQueryFailed => write!(f, "Media query failed"),
             Error::MediaQueryNotSupported => write!(f, "Media query not supported"),
+            Error::Unsupported => write!(
+                f,
+                "Watching for theme changes is not supported on this platform"
+            ),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,18 +67,20 @@ pub use platforms::platform::subscribe;
 ///
 /// ``` no_run
 /// use dark_light::{ Error, Mode };
-/// use futures::StreamExt;
+/// use futures_util::StreamExt;
 ///
-/// async fn main() -> Result<(), Error> {
-///     let mut stream = dark_light::stream()?;
-///     while let Some(mode) = stream.next().await {
-///         match mode {
-///             Mode::Dark => {},
-///             Mode::Light => {},
-///             Mode::Unspecified => {},
+/// fn main() -> Result<(), Error> {
+///     futures_executor::block_on(async {
+///         let mut stream = dark_light::stream()?;
+///         while let Some(mode) = stream.next().await {
+///             match mode {
+///                 Mode::Dark => {},
+///                 Mode::Light => {},
+///                 Mode::Unspecified => {},
+///             }
 ///         }
-///     }
-///     Ok(())
+///         Ok(())
+///     })
 /// }
 /// ```
 #[cfg(any(feature = "tokio", feature = "async-io"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,11 @@
 mod error;
 mod mode;
 mod platforms;
+mod watch;
 
 pub use error::Error;
 pub use mode::Mode;
+pub use watch::Watcher;
 
 /// Detects the system theme mode.
 ///
@@ -29,3 +31,28 @@ pub use mode::Mode;
 /// }
 /// ```
 pub use platforms::platform::detect;
+
+/// Subscribes to changes in the system theme mode.
+///
+/// Returns a [`Watcher`] that receives a new [`Mode`] each time the OS theme changes.
+/// Only mode transitions are emitted, and the watcher's background thread (where used)
+/// stops when the `Watcher` is dropped.
+///
+/// # Example
+///
+/// ``` no_run
+/// use dark_light::{ Error, Mode };
+///
+/// fn main() -> Result<(), Error> {
+///     let watcher = dark_light::subscribe()?;
+///     for mode in watcher.iter() {
+///         match mode {
+///             Mode::Dark => {},
+///             Mode::Light => {},
+///             Mode::Unspecified => {},
+///         }
+///     }
+///     Ok(())
+/// }
+/// ```
+pub use platforms::platform::subscribe;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 mod error;
 mod mode;
 mod platforms;
+#[cfg(any(feature = "tokio", feature = "async-io"))]
+mod stream;
 mod watch;
 
 pub use error::Error;
@@ -56,3 +58,28 @@ pub use platforms::platform::detect;
 /// }
 /// ```
 pub use platforms::platform::subscribe;
+
+/// Subscribes to changes in the system theme mode using an async stream.
+///
+/// Returns a [`Stream`] that yields a new [`Mode`] each time the OS theme changes.
+///
+/// # Example
+///
+/// ``` no_run
+/// use dark_light::{ Error, Mode };
+/// use futures::StreamExt;
+///
+/// async fn main() -> Result<(), Error> {
+///     let mut stream = dark_light::stream()?;
+///     while let Some(mode) = stream.next().await {
+///         match mode {
+///             Mode::Dark => {},
+///             Mode::Light => {},
+///             Mode::Unspecified => {},
+///         }
+///     }
+///     Ok(())
+/// }
+/// ```
+#[cfg(any(feature = "tokio", feature = "async-io"))]
+pub use stream::stream;

--- a/src/platforms/freedesktop.rs
+++ b/src/platforms/freedesktop.rs
@@ -1,4 +1,7 @@
-use crate::{Error, Mode};
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+
+use crate::{Error, Mode, Watcher};
 use zbus::proxy;
 use zbus::zvariant::OwnedValue;
 
@@ -12,6 +15,9 @@ const PORTAL_DESTINATION: &str = "org.freedesktop.portal.Desktop";
 )]
 pub trait XdgPortalSettings {
     fn read_one(&self, namespace: &str, key: &str) -> zbus::Result<OwnedValue>;
+
+    #[zbus(signal)]
+    fn setting_changed(&self, namespace: &str, key: &str, value: OwnedValue) -> zbus::Result<()>;
 }
 
 pub fn detect() -> Result<Mode, Error> {
@@ -28,5 +34,54 @@ pub fn detect() -> Result<Mode, Error> {
         1 => Mode::Dark,
         2 => Mode::Light,
         _ => Mode::Unspecified,
+    })
+}
+
+/// Background handle for a Linux/BSD theme watcher.
+///
+/// The watcher thread blocks on the D-Bus session connection's signal stream, which has
+/// no external cancellation mechanism; it is detached rather than joined on drop and will
+/// exit the next time it observes that the channel receiver has been dropped.
+pub struct WatchGuard(#[allow(dead_code)] Option<JoinHandle<()>>);
+
+pub fn subscribe() -> Result<Watcher, Error> {
+    let (sender, receiver) = mpsc::channel();
+
+    let conn = zbus::blocking::Connection::session()
+        .map_err(|e| Error::XdgDesktopPortal(e.to_string()))?;
+    let portal = XdgPortalSettingsProxyBlocking::new(&conn, PORTAL_DESTINATION)
+        .map_err(|e| Error::XdgDesktopPortal(e.to_string()))?;
+    let changes = portal
+        .receive_setting_changed()
+        .map_err(|e| Error::XdgDesktopPortal(e.to_string()))?;
+
+    let handle = std::thread::spawn(move || {
+        let mut last = None;
+        for signal in changes {
+            let Ok(args) = signal.args() else { continue };
+            if args.namespace != APPEARANCE || args.key != COLOR_SCHEME {
+                continue;
+            }
+            let Ok(value): Result<u32, _> = args.value.try_into() else {
+                continue;
+            };
+            let mode = match value {
+                1 => Mode::Dark,
+                2 => Mode::Light,
+                _ => Mode::Unspecified,
+            };
+            if Some(mode) == last {
+                continue;
+            }
+            last = Some(mode);
+            if sender.send(mode).is_err() {
+                break;
+            }
+        }
+    });
+
+    Ok(Watcher {
+        receiver,
+        guard: WatchGuard(Some(handle)),
     })
 }

--- a/src/platforms/macos.rs
+++ b/src/platforms/macos.rs
@@ -1,7 +1,13 @@
 // Dark/light mode detection on macOS.
 // Written with help from Ryan McGrath (https://rymc.io/).
 
-use crate::{Error, Mode};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use crate::{Error, Mode, Watcher};
 use objc2_foundation::{ns_string, NSString, NSUserDefaults};
 
 pub fn detect() -> Result<Mode, Error> {
@@ -19,6 +25,58 @@ pub fn detect() -> Result<Mode, Error> {
     };
     let mode = style.isEqualToString(ns_string!("Dark")).into();
     Ok(mode)
+}
+
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Background handle for a macOS theme watcher.
+///
+/// macOS theme changes are observed by polling [`detect`] on an interval, since
+/// registering for `NSDistributedNotificationCenter`'s
+/// `AppleInterfaceThemeChangedNotification` requires an Objective-C delegate object and a
+/// live `NSRunLoop`, which the objc2 bindings currently in use don't expose a safe,
+/// block-based path for.
+pub struct WatchGuard {
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for WatchGuard {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+pub fn subscribe() -> Result<Watcher, Error> {
+    let (sender, receiver) = mpsc::channel();
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let mut last = detect()?;
+    let watcher_stop = Arc::clone(&stop);
+    let handle = std::thread::spawn(move || {
+        while !watcher_stop.load(Ordering::Relaxed) {
+            std::thread::sleep(POLL_INTERVAL);
+            let Ok(mode) = detect() else { continue };
+            if mode == last {
+                continue;
+            }
+            last = mode;
+            if sender.send(mode).is_err() {
+                break;
+            }
+        }
+    });
+
+    Ok(Watcher {
+        receiver,
+        guard: WatchGuard {
+            stop,
+            handle: Some(handle),
+        },
+    })
 }
 
 #[cfg(test)]

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -42,9 +42,15 @@ pub use websys as platform;
     target_arch = "wasm32"
 )))]
 pub mod platform {
-    use crate::Mode;
+    use crate::{Error, Mode, Watcher};
 
     pub fn detect() -> Mode {
         Mode::Light
+    }
+
+    pub struct WatchGuard;
+
+    pub fn subscribe() -> Result<Watcher, Error> {
+        Err(Error::Unsupported)
     }
 }

--- a/src/platforms/websys.rs
+++ b/src/platforms/websys.rs
@@ -1,4 +1,8 @@
-use crate::{Error, Mode};
+use std::sync::mpsc;
+
+use crate::{Error, Mode, Watcher};
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::JsCast;
 
 pub fn detect() -> Result<Mode, Error> {
     let window = web_sys::window().ok_or(Error::WindowNotFound)?;
@@ -7,4 +11,44 @@ pub fn detect() -> Result<Mode, Error> {
         .map_err(|_| Error::MediaQueryFailed)?;
     let mql = query_result.ok_or(Error::MediaQueryNotSupported)?;
     Ok((mql.matches()).into())
+}
+
+/// Background handle for a WASM theme watcher.
+///
+/// Holds the `MediaQueryList` and its `change` listener closure alive; both are removed
+/// and dropped when the guard is dropped.
+pub struct WatchGuard {
+    mql: web_sys::MediaQueryList,
+    closure: Closure<dyn FnMut(web_sys::Event)>,
+}
+
+impl Drop for WatchGuard {
+    fn drop(&mut self) {
+        let _ = self
+            .mql
+            .remove_event_listener_with_callback("change", self.closure.as_ref().unchecked_ref());
+    }
+}
+
+pub fn subscribe() -> Result<Watcher, Error> {
+    let window = web_sys::window().ok_or(Error::WindowNotFound)?;
+    let query_result = window
+        .match_media("(prefers-color-scheme: dark)")
+        .map_err(|_| Error::MediaQueryFailed)?;
+    let mql = query_result.ok_or(Error::MediaQueryNotSupported)?;
+
+    let (sender, receiver) = mpsc::channel();
+    let watched = mql.clone();
+    let closure = Closure::<dyn FnMut(web_sys::Event)>::new(move |_event: web_sys::Event| {
+        let mode: Mode = watched.matches().into();
+        let _ = sender.send(mode);
+    });
+
+    mql.add_event_listener_with_callback("change", closure.as_ref().unchecked_ref())
+        .map_err(|_| Error::MediaQueryFailed)?;
+
+    Ok(Watcher {
+        receiver,
+        guard: WatchGuard { mql, closure },
+    })
 }

--- a/src/platforms/websys.rs
+++ b/src/platforms/websys.rs
@@ -4,6 +4,11 @@ use crate::{Error, Mode, Watcher};
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 
+#[cfg(any(feature = "tokio", feature = "async-io"))]
+use std::pin::Pin;
+#[cfg(any(feature = "tokio", feature = "async-io"))]
+use std::task::{Context, Poll};
+
 pub fn detect() -> Result<Mode, Error> {
     let window = web_sys::window().ok_or(Error::WindowNotFound)?;
     let query_result = window
@@ -50,5 +55,55 @@ pub fn subscribe() -> Result<Watcher, Error> {
     Ok(Watcher {
         receiver,
         guard: WatchGuard { mql, closure },
+    })
+}
+
+#[cfg(any(feature = "tokio", feature = "async-io"))]
+struct MediaQueryStream {
+    mql: web_sys::MediaQueryList,
+    closure: Closure<dyn FnMut(web_sys::Event)>,
+    receiver: futures_channel::mpsc::UnboundedReceiver<Mode>,
+}
+
+#[cfg(any(feature = "tokio", feature = "async-io"))]
+impl Drop for MediaQueryStream {
+    fn drop(&mut self) {
+        let _ = self
+            .mql
+            .remove_event_listener_with_callback("change", self.closure.as_ref().unchecked_ref());
+    }
+}
+
+#[cfg(any(feature = "tokio", feature = "async-io"))]
+impl futures_core::Stream for MediaQueryStream {
+    type Item = Mode;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Mode>> {
+        Pin::new(&mut self.receiver).poll_next(cx)
+    }
+}
+
+#[cfg(any(feature = "tokio", feature = "async-io"))]
+pub fn stream() -> Result<impl futures_core::Stream<Item = Mode>, Error> {
+    let window = web_sys::window().ok_or(Error::WindowNotFound)?;
+    let query_result = window
+        .match_media("(prefers-color-scheme: dark)")
+        .map_err(|_| Error::MediaQueryFailed)?;
+    let mql = query_result.ok_or(Error::MediaQueryNotSupported)?;
+
+    let (sender, receiver) = futures_channel::mpsc::unbounded();
+    let watched = mql.clone();
+    let closure = Closure::<dyn FnMut(web_sys::Event)>::new(move |_event: web_sys::Event| {
+        let mode: Mode = watched.matches().into();
+        let _ = sender.unbounded_send(mode);
+    });
+
+    mql.add_event_listener_with_callback("change", closure.as_ref().unchecked_ref())
+        .map_err(|_| Error::MediaQueryFailed)?;
+
+    Ok(MediaQueryStream {
+        mql,
+        closure,
+        receiver,
     })
 }

--- a/src/platforms/windows.rs
+++ b/src/platforms/windows.rs
@@ -22,7 +22,7 @@ pub struct WatchGuard {
     handle: Option<JoinHandle<()>>,
 }
 
-// SAFETY: `HKEY` is an opaque registry handle value; it is safe to hand off to the
+// `HKEY` is an opaque registry handle value; it is safe to hand off to the
 // watcher thread, which becomes its sole owner until the thread exits.
 unsafe impl Send for WatchGuard {}
 
@@ -37,7 +37,7 @@ impl Drop for WatchGuard {
     }
 }
 
-// SAFETY: `HKEY` is an opaque registry handle value with no thread affinity; the Win32
+// `HKEY` is an opaque registry handle value with no thread affinity; the Win32
 // registry API is safe to call from any thread.
 struct SendHkey(HKEY);
 unsafe impl Send for SendHkey {}

--- a/src/platforms/windows.rs
+++ b/src/platforms/windows.rs
@@ -1,12 +1,99 @@
-use crate::{Error, Mode};
-use winreg::RegKey;
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+
+use crate::{Error, Mode, Watcher};
+use windows_sys::Win32::System::Registry::{RegNotifyChangeKeyValue, REG_NOTIFY_CHANGE_LAST_SET};
+use winreg::enums::{HKEY_CURRENT_USER, KEY_NOTIFY, KEY_READ};
+use winreg::{RegKey, HKEY};
 
 const SUBKEY: &str = "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
 const VALUE: &str = "AppsUseLightTheme";
 
 pub fn detect() -> Result<Mode, Error> {
-    let hkcu = RegKey::predef(winreg::enums::HKEY_CURRENT_USER);
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
     let subkey = hkcu.open_subkey(SUBKEY)?;
     let dword: u32 = subkey.get_value(VALUE)?;
     Ok((dword == 0).into())
+}
+
+/// Background handle for a Windows theme watcher.
+pub struct WatchGuard {
+    hkey: HKEY,
+    handle: Option<JoinHandle<()>>,
+}
+
+// SAFETY: `HKEY` is an opaque registry handle value; it is safe to hand off to the
+// watcher thread, which becomes its sole owner until the thread exits.
+unsafe impl Send for WatchGuard {}
+
+impl Drop for WatchGuard {
+    fn drop(&mut self) {
+        // Closing the handle unblocks a pending `RegNotifyChangeKeyValue` call, letting
+        // the watcher thread observe the error and exit so we can join it.
+        unsafe { windows_sys::Win32::System::Registry::RegCloseKey(self.hkey) };
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+// SAFETY: `HKEY` is an opaque registry handle value with no thread affinity; the Win32
+// registry API is safe to call from any thread.
+struct SendHkey(HKEY);
+unsafe impl Send for SendHkey {}
+
+pub fn subscribe() -> Result<Watcher, Error> {
+    let (sender, receiver) = mpsc::channel();
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let key = hkcu.open_subkey_with_flags(SUBKEY, KEY_READ | KEY_NOTIFY)?;
+    let raw_hkey = key.raw_handle();
+    // The handle now lives on for the watcher thread; `WatchGuard::drop` closes it.
+    std::mem::forget(key);
+    let send_hkey = SendHkey(raw_hkey);
+
+    let handle = std::thread::spawn(move || {
+        let send_hkey = send_hkey;
+        let hkey = send_hkey.0;
+        let mut last = None;
+        loop {
+            let status = unsafe {
+                RegNotifyChangeKeyValue(
+                    hkey,
+                    0,
+                    REG_NOTIFY_CHANGE_LAST_SET,
+                    std::ptr::null_mut(),
+                    0,
+                )
+            };
+            if status != 0 {
+                break;
+            }
+            // Re-open a fresh handle to read the value: the notify handle above isn't a
+            // `winreg::RegKey`, so it has no typed read API of its own.
+            let dword: u32 = match RegKey::predef(HKEY_CURRENT_USER)
+                .open_subkey(SUBKEY)
+                .and_then(|k| k.get_value(VALUE))
+            {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            let mode: Mode = (dword == 0).into();
+            if Some(mode) == last {
+                continue;
+            }
+            last = Some(mode);
+            if sender.send(mode).is_err() {
+                break;
+            }
+        }
+    });
+
+    Ok(Watcher {
+        receiver,
+        guard: WatchGuard {
+            hkey: raw_hkey,
+            handle: Some(handle),
+        },
+    })
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,49 @@
+use futures_core::Stream;
+
+use crate::{Error, Mode};
+
+/// Subscribes to theme changes as an async [`Stream`].
+///
+/// This is an adapter over [`crate::subscribe`]. On most platforms it drives the
+/// underlying blocking [`crate::Watcher`] on a background thread and forwards each
+/// [`Mode`] into the returned stream. On `wasm32` (which has no threads here), the
+/// browser's `MediaQueryList` `change` event is forwarded directly instead.
+///
+/// # Example
+///
+/// ``` no_run
+/// use dark_light::{ Error, Mode };
+/// use futures_util::StreamExt;
+///
+/// fn main() -> Result<(), Error> {
+///     futures_executor::block_on(async {
+///         let mut stream = dark_light::stream()?;
+///         while let Some(mode) = stream.next().await {
+///             match mode {
+///                 Mode::Dark => {},
+///                 Mode::Light => {},
+///                 Mode::Unspecified => {},
+///             }
+///         }
+///         Ok(())
+///     })
+/// }
+/// ```
+#[cfg(not(target_arch = "wasm32"))]
+pub fn stream() -> Result<impl Stream<Item = Mode>, Error> {
+    let watcher = crate::subscribe()?;
+    let (tx, rx) = futures_channel::mpsc::unbounded();
+    std::thread::spawn(move || {
+        for mode in watcher.iter() {
+            if tx.unbounded_send(mode).is_err() {
+                break;
+            }
+        }
+    });
+    Ok(rx)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn stream() -> Result<impl Stream<Item = Mode>, Error> {
+    crate::platforms::websys::stream()
+}

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,38 @@
+use std::sync::mpsc;
+
+use crate::Mode;
+
+/// A handle to a background theme-change watcher.
+///
+/// Dropping the `Watcher` stops the underlying platform watcher and joins its
+/// background thread (where applicable).
+///
+/// Only mode transitions are emitted: if the OS reports the same mode twice
+/// in a row, no duplicate message is sent.
+pub struct Watcher {
+    pub(crate) receiver: mpsc::Receiver<Mode>,
+    #[allow(dead_code)]
+    pub(crate) guard: crate::platforms::platform::WatchGuard,
+}
+
+impl Watcher {
+    /// Blocks until the next theme change is received.
+    pub fn recv(&self) -> Result<Mode, mpsc::RecvError> {
+        self.receiver.recv()
+    }
+
+    /// Returns the next theme change if one is already available, without blocking.
+    pub fn try_recv(&self) -> Result<Mode, mpsc::TryRecvError> {
+        self.receiver.try_recv()
+    }
+
+    /// Returns a blocking iterator over theme changes.
+    pub fn iter(&self) -> mpsc::Iter<'_, Mode> {
+        self.receiver.iter()
+    }
+
+    /// Returns a non-blocking iterator that yields only already-available theme changes.
+    pub fn try_iter(&self) -> mpsc::TryIter<'_, Mode> {
+        self.receiver.try_iter()
+    }
+}


### PR DESCRIPTION
## Summary
Consumers previously had no way to react to OS theme changes short of polling `detect()` themselves. This adds two new entry points, both built on a shared, channel-based `Watcher`:

- `subscribe() -> Result<Watcher, Error>`: a blocking function usable from any thread or event-loop poll, with no async runtime required.
- `stream() -> Result<impl Stream<Item = Mode>, Error>`:  an async adapter over the same watcher, gated behind the  `tokio`/`async-io` features, for frameworks (e.g. Iced) that consume `futures::Stream`s directly.

Only mode transitions are emitted.

## Per-platform implementation
- **Linux/BSD**: subscribes to the XDG portal's `SettingChanged` D-Bus signal via zbus's blocking signal iterator.
- **Windows**: watches the registry via `RegNotifyChangeKeyValue` on a background thread.
- **macOS**: polls `detect()` every second on a background thread.

> [!IMPORTANT]  
> Native `NSDistributedNotificationCenter` observation was investigated but requires a hand-rolled `define_class!` delegate and a live `NSRunLoop`, which isn't safely exposed by the objc2 bindings in use — polling is the fallback for now.

- **WASM**: forwards `MediaQueryList`'s native `change` event directly, no thread, since wasm32 has none available here.
- **Unsupported targets**: `subscribe()`/`stream()` return `Error::Unsupported`.

## Notes
- `stream()` reuses `subscribe()` internally: on native platforms it bridges the blocking `Watcher` onto a background thread and forwards into a `futures_channel::mpsc` stream; on wasm32 it skips the thread entirely and forwards from the same DOM event listener used by `subscribe()`.

Closes https://github.com/rust-dark-light/dark-light/issues/68